### PR TITLE
Enforce import order & remove deprecated settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "prettier-plugin-organize-imports": "^3.2.2"
   },
   "devDependencies": {
-    "prettier": "2.8.3"
+    "prettier": "2.8.3",
+    "typescript": "4.9.4"
   },
   "peerDependencies": {
-    "prettier": "^2.4.0"
+    "prettier": ">=2.4",
+    "typescript": ">=2.9"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "prettier": "./prettier.config.js",
   "dependencies": {
-    "prettier-plugin-organize-imports": "^3.2.2"
+    "prettier-plugin-organize-imports": "3.2.2"
   },
   "devDependencies": {
     "prettier": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "format:check": "prettier --ignore-path='.gitignore' --check ."
   },
   "prettier": "./prettier.config.js",
+  "dependencies": {
+    "prettier-plugin-organize-imports": "^3.2.2"
+  },
   "devDependencies": {
     "prettier": "2.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier": "2.8.3"
   },
   "peerDependencies": {
-    "prettier": "^2.3.1"
+    "prettier": "^2.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,6 @@
+// In addition to this config, we also install the "organize-imports" plugin, which makes Prettier
+// organize `import`s using the TypeScript language service API (like "Organize Imports" in VS Code).
+
 module.exports = {
   printWidth: 100,
   tabWidth: 2,

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -12,7 +12,6 @@ module.exports = {
   trailingComma: 'es5',
   bracketSpacing: true,
   bracketSameLine: false,
-  jsxBracketSameLine: false, // Deprecated
   arrowParens: 'always',
   proseWrap: 'always',
   endOfLine: 'lf',

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,6 @@
 // In addition to this config, we also install the "organize-imports" plugin, which makes Prettier
 // organize `import`s using the TypeScript language service API (like "Organize Imports" in VS Code).
+// (This is also where the peer dependency on TypeScript comes from.)
 
 module.exports = {
   printWidth: 100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-prettier-plugin-organize-imports@^3.2.2:
+prettier-plugin-organize-imports@3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz#91993365e017daa5d0d28d8183179834224d8dd1"
   integrity sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+prettier-plugin-organize-imports@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz#91993365e017daa5d0d28d8183179834224d8dd1"
+  integrity sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==
+
 prettier@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,3 +11,8 @@ prettier@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
+
+typescript@4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==


### PR DESCRIPTION
- Add "organize-imports" plugin
- Remove deprecated jsxBracketSameLine
- Bump peer dependencies
- Pin plugin version
